### PR TITLE
Add token interceptor for truncating git commit message

### DIFF
--- a/scripts/hipChatClient.js
+++ b/scripts/hipChatClient.js
@@ -152,6 +152,7 @@ HipChatClient.prototype.run = function (source, params) {
   self.sendMessage(source, params, (error, result) => {
     if (error) {
       console.error(`Error sending notification. Fail on error: ${self.failOnError}`);
+      console.error(`Attempted to send message: ${params.message}`);
       console.error(error);
       if (self.failOnError) {
         process.exit(1);

--- a/scripts/test/tokenInterceptorTests.js
+++ b/scripts/test/tokenInterceptorTests.js
@@ -1,0 +1,81 @@
+var rewire = require('rewire'),
+  sinon = require('sinon'),
+  sut = rewire('../tokenInterceptors');
+
+describe('Default Token Interceptor', function () {
+  it('should accept tokens "as-is" (no-op)', function () {
+    var acceptSpy = sinon.spy();
+    var rejectSpy = sinon.spy();
+
+    sut.defaultInterceptor("some_key", "some_value", acceptSpy, rejectSpy);
+
+    sinon.assert.calledOnce(acceptSpy);
+    sinon.assert.calledWith(acceptSpy, "some_key", "some_value");
+
+    sinon.assert.notCalled(rejectSpy);
+  });
+
+  it('should accept null tokens', function () {
+    var acceptSpy = sinon.spy();
+    var rejectSpy = sinon.spy();
+
+    sut.defaultInterceptor(null, null, acceptSpy, rejectSpy);
+
+    sinon.assert.calledOnce(acceptSpy);
+    sinon.assert.calledWith(acceptSpy, null, null);
+
+    sinon.assert.notCalled(rejectSpy);
+  });
+});
+
+describe('Truncating Token Interceptor', function () {
+  it("should truncate value for token GIT_COMMIT_MESSAGE at first line break", function () {
+    var acceptSpy = sinon.spy();
+    var rejectSpy = sinon.spy();
+
+    sut.truncatingInterceptor("GIT_COMMIT_MESSAGE", "This is the summary statement for the commit\n\nThat has much more content on newlines.", acceptSpy, rejectSpy);
+
+    sinon.assert.calledOnce(acceptSpy);
+    sinon.assert.calledWith(acceptSpy, "GIT_COMMIT_MESSAGE", "This is the summary statement for the commit");
+
+    sinon.assert.notCalled(rejectSpy);
+  });
+
+  it("should truncate value for token GIT_COMMIT_MESSAGE at 75 characters", function () {
+    var acceptSpy = sinon.spy();
+    var rejectSpy = sinon.spy();
+
+    const reallyLongMessage = "A".repeat(100) + "\n\n" + "B".repeat(50);
+
+    sut.truncatingInterceptor("GIT_COMMIT_MESSAGE", reallyLongMessage, acceptSpy, rejectSpy);
+
+    sinon.assert.calledOnce(acceptSpy);
+    sinon.assert.calledWith(acceptSpy, "GIT_COMMIT_MESSAGE", "A".repeat(75) + "...");
+
+    sinon.assert.notCalled(rejectSpy);
+  });
+
+  it('should accept all other tokens "as-is" (no-op)', function () {
+    var acceptSpy = sinon.spy();
+    var rejectSpy = sinon.spy();
+
+    sut.truncatingInterceptor("some_key", "some_value\nwhere newlines are accepted", acceptSpy, rejectSpy);
+
+    sinon.assert.calledOnce(acceptSpy);
+    sinon.assert.calledWith(acceptSpy, "some_key", "some_value\nwhere newlines are accepted");
+
+    sinon.assert.notCalled(rejectSpy);
+  });
+
+  it('should accept null tokens', function () {
+    var acceptSpy = sinon.spy();
+    var rejectSpy = sinon.spy();
+
+    sut.truncatingInterceptor(null, null, acceptSpy, rejectSpy);
+
+    sinon.assert.calledOnce(acceptSpy);
+    sinon.assert.calledWith(acceptSpy, null, null);
+
+    sinon.assert.notCalled(rejectSpy);
+  });
+});

--- a/scripts/tokenInterceptors.js
+++ b/scripts/tokenInterceptors.js
@@ -1,0 +1,57 @@
+module.exports = {
+  /**
+   * Default token interceptor that accepts all token replacements.
+   *
+   * @param key token key (without surrounding "${}").
+   * @param value value to replace all occurrences of token key in message.
+   * @param accept callback for the interceptor to accept the token key/value for replacement in the message.  Callback args: (key,value)
+   * @param reject callback for the interceptor to reject token replacement for the given key.  Any/all occurrences of the
+   * key will be removed from the final message.  Callback args: (key)
+   */
+  defaultInterceptor: function (key, value, accept, reject) {
+    accept(key, value);
+  },
+
+  /**
+   * Token interceptor that truncates some token values.  This interceptor truncates based on two criterion:<br>
+   *   1) Truncate at first newline (\n) character for the following token keys:
+   *     * <code>GIT_COMMIT_MESSAGE</code>
+   *   2) Truncate at 75 characters for the following token keys:
+   *     * <code>GIT_COMMIT_MESSAGE</code>
+   *
+   * Once any truncating is performed, handling of the (potentially) truncated token is then deferred to {@link defaultInterceptor}.
+   *
+   * @param key token key (without surrounding "${}").
+   * @param value value to replace all occurrences of token key in message.
+   * @param accept callback for the interceptor to accept the token key/value for replacement in the message.  Callback args: (key,value)
+   * @param reject callback for the interceptor to reject token replacement for the given key.  Any/all occurrences of the
+   * key will be removed from the final message.  Callback args: (key)
+   * @see defaultInterceptor
+   */
+  truncatingInterceptor: function (key, value, accept, reject) {
+    if (key && value && typeof key === 'string' && typeof value === 'string') {
+      const AT_NEWLINE_TOKENS = ["GIT_COMMIT_MESSAGE"];
+      const AT_LENGTH_TOKENS = ["GIT_COMMIT_MESSAGE"];
+
+      if (value.includes("\n")) {
+        AT_NEWLINE_TOKENS.some(function (token) {
+          if (token === key) {
+            value = value.substring(0, value.indexOf("\n"));
+            return true;
+          }
+        });
+      }
+
+      if (value.length > 75) {
+        AT_LENGTH_TOKENS.some(function (token) {
+          if (token === key) {
+            value = value.substring(0, 75) + "...";
+            return true;
+          }
+        })
+      }
+    }
+
+    module.exports.defaultInterceptor(key, value, accept, reject);
+  }
+};


### PR DESCRIPTION
Added new skaffolding for supporting "interceptors" in the token
replacement process.  Two new interceptors were created:

1. A "default" interceptor which accepts all token keys/values.
2. A "truncating" interceptor which truncates values for specific keys.

The "truncating" interceptor only activates (currently) on the key
`GIT_COMMIT_MESSAGE`.  It truncates according to two rules:

**Rule 1:** At the first newline `\n` character (summary statement).
**Rule 2:** At 75 characters (with a `...` appended).

This helps to ensure we don't overrun the message length.